### PR TITLE
Fix entity id generator

### DIFF
--- a/src/ecs.zig
+++ b/src/ecs.zig
@@ -400,7 +400,7 @@ pub fn App(comptime desc: AppDesc) type {
                 ent.incGen();
                 return ent;
             } else {
-                const ent = Entity.new(self.entities.count);
+                const ent = Entity.new(self.entities.count + 1); // avoid using 0 which is our .placeholder
                 self.entities.count += 1;
                 return ent;
             }

--- a/src/ecs.zig
+++ b/src/ecs.zig
@@ -228,11 +228,6 @@ pub fn App(comptime desc: AppDesc) type {
             try self.systems.init(self.memtator.world());
         }
 
-        const EntityRegistry = struct {
-            unused: std.ArrayList(Entity) = .{},
-            count: u32 = 0,
-        };
-
         ///! valid check
         pub fn isValid(self: *const World, ent: Entity) bool {
             return self.components.entity_lookup.contains(ent);

--- a/src/ecs_test.zig
+++ b/src/ecs_test.zig
@@ -68,10 +68,11 @@ test "commands" {
     defer ecs.deinit();
 
     const cmd = ecs.getCommands();
-    _ = try cmd.spawn(.{Foo{ .n = 69 }});
+    const entity = try cmd.spawn(.{Foo{ .n = 69 }});
 
     ecs.update();
     try expect(ecs.entities.count == 1);
+    try expect(entity.id() == 1);
 
     const q = try App(.{}).Query(.{Foo}).fromWorld(&ecs);
     var view = q.iterQ(struct { entity: Entity, foo: *const Foo });


### PR DESCRIPTION
This just ensures the first created entity isnt `.placeholder`